### PR TITLE
Update preload.js

### DIFF
--- a/app/templates/game/states/preload.js
+++ b/app/templates/game/states/preload.js
@@ -1,4 +1,3 @@
-
 'use strict';
 function Preload() {
   this.asset = null;
@@ -7,7 +6,7 @@ function Preload() {
 
 Preload.prototype = {
   preload: function() {
-    this.asset = this.add.sprite(this.width/2,this.height/2, 'preloader');
+    this.asset = this.add.sprite(this.game.width/2,this.game.height/2, 'preloader');
     this.asset.anchor.setTo(0.5, 0.5);
 
     this.load.onLoadComplete.addOnce(this.onLoadComplete, this);


### PR DESCRIPTION
Hey! I noticed you have: 

```
this.width/2 && this.height/2
```

instead of:

```
this.game.width/2 && this.game.height/2
```

Don't know if you did that on purpose for some reason, (still a beginner), but adding game in there makes it center no matter what screen option you put for original generator input!
(In your tutorials the loader shows up in the top right instead of center) 

Anyways love the generator! 
Can not thank you enough for it since 
I come from a node, yo, grunt background.
